### PR TITLE
Introduces a CircleCI configuration

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,70 @@
+version: 2.1
+
+jobs:
+  test:
+    working_directory: ~/digital_collections_elixir_example
+    docker:
+      - image: circleci/elixir:1.9-node
+        environment:
+          DATABASE_URL: ecto://root@localhost/circle_test
+          MIX_ENV: test
+          HTTP_PORT: 4000
+          DB_PORT: 5432
+          ELASTIC_SEARCH_URL: http://localhost:9200
+      - image: circleci/postgres:10-alpine
+        environment:
+          POSTGRES_USER: docker
+          POSTGRES_PASSWORD: d0ck3r
+      - image: docker.elastic.co/elasticsearch/elasticsearch:6.3.2
+        environment:
+          discovery.type: single-node
+          http.cors.enabled: "true"
+          http.cors.allow-origin: "*"
+          http.cors.allow-methods: OPTIONS, HEAD, GET, POST, PUT, DELETE
+          http.cors.allow-headers: "X-Requested-With,X-Auth-Token,Content-Type, Content-Length, Authorization"
+    steps:
+      - checkout
+      - restore_cache:
+          keys:
+            - v1-hex-cache-{{ checksum "mix.lock" }}
+            - v1-hex-cache-
+            - dependency-cache-
+      - restore_cache:
+          keys:
+            - v1-npm-cache-{{ checksum "assets/yarn.lock" }}
+            - v1-npm-cache-
+      - run:
+          name: Install hex & rebar
+          command: mix do local.hex --force, local.rebar --force
+      - run:
+          name: Install Elixir Dependencies
+          command: mix do deps.get
+      - run:
+          name: Install JS Dependencies
+          command: yarn install
+          working_directory: ~/digital_collections_elixir_example/assets
+      - save_cache:
+          key: v1-hex-cache-{{ checksum "mix.lock" }}
+          paths:
+            - ~/digital_collections_elixir_example/deps
+            - ~/digital_collections_elixir_example/_build
+      - save_cache:
+          key: v1-npm-cache-{{ checksum "assets/yarn.lock" }}
+          paths:
+            - ~/digital_collections_elixir_example/assets/node_modules
+      - run:
+          name: Elixir Tests
+          command: mix test && (mix coveralls.circle || true)
+      - run:
+          name: Test Webpack Build
+          command: yarn deploy
+          working_directory: ~/digital_collections_elixir_example/assets
+      - store_artifacts:
+          path: /tmp/test-results
+          destination: tests
+
+workflows:
+  ci:
+    jobs:
+      - test
+

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -16,9 +16,6 @@ import "phoenix_html";
 // Local files can be imported directly using relative paths, for example:
 // import socket from "./socket"
 
-// Import non-Lux Vue components
-import "./components/_components";
-
 // Import Vue & Lux
 import Vue from "vue";
 import system from "lux-design-system";

--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -16,6 +16,9 @@ import "phoenix_html";
 // Local files can be imported directly using relative paths, for example:
 // import socket from "./socket"
 
+// Import non-Lux Vue components
+import "./components/_components";
+
 // Import Vue & Lux
 import Vue from "vue";
 import system from "lux-design-system";

--- a/config/config.exs
+++ b/config/config.exs
@@ -27,7 +27,7 @@ config :phoenix, :json_library, Jason
 
 config :digital_collex, DigitalCollex.ElasticsearchCluster,
   # The URL where Elasticsearch is hosted on your system
-  url: "http://localhost:9201",
+  url: System.get_env("ELASTIC_SEARCH_URL", "http://localhost:9201"),
 
   # If your Elasticsearch cluster uses HTTP basic authentication,
   # specify the username and password here:

--- a/config/test.exs
+++ b/config/test.exs
@@ -6,13 +6,13 @@ config :digital_collex, DigitalCollex.Repo,
   password: "d0ck3r",
   database: "digital_collex_test",
   hostname: "localhost",
-  port: 5434,
+  port: System.get_env("DB_PORT", "5434"),
   pool: Ecto.Adapters.SQL.Sandbox
 
 # We don't run a server during test. If one is required,
 # you can enable the server option below.
 config :digital_collex, DigitalCollexWeb.Endpoint,
-  http: [port: 4002],
+  http: [port: System.get_env("HTTP_PORT", "4002")],
   server: false
 
 # Print only warnings and errors during test

--- a/test/support/test_cluster.ex
+++ b/test/support/test_cluster.ex
@@ -8,7 +8,7 @@ defmodule DigitalCollex.Elasticsearch.Test.Cluster do
      %{
        api: Elasticsearch.API.HTTP,
        json_library: Jason,
-       url: "http://localhost:9202",
+       url: System.get_env("ELASTIC_SEARCH_URL", "http://localhost:9202"),
        indexes: %{
          resources: %{
            settings: "priv/elasticsearch/resources.json",


### PR DESCRIPTION
Introduces a CircleCI configuration, along with using environment variables in order to enable testing with different port numbers for PostgreSQL and Elasticsearch. Resolves #18 